### PR TITLE
jo/errorhandler

### DIFF
--- a/.docker/docker-compose.yml
+++ b/.docker/docker-compose.yml
@@ -1,0 +1,9 @@
+version: '3.1'
+services:
+  mongo:
+    image: mongo
+    restart: always
+    ports:
+      - 27017:27017
+    environment:
+      MONGO_INITDB_DATABASE: TodoListDB

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,7 @@
+# Objectif
+
+# Implémentation
+
+# Améliorations générales
+
+# Extension, alternatives...

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
+/.idea/
 node_modules
 npm-debug.log

--- a/api/controller/todoList.js
+++ b/api/controller/todoList.js
@@ -3,38 +3,41 @@ const todoItem = require('../model/todoItem');
 const mongoose = require('mongoose');
 const TodoItem = mongoose.model('TodoItem', todoItem);
 
-function respond(err, result, res) {
+function respond(err, result, res, next) {
   if (err) {
-    return res.status(500).json({error: err});
+    if(err instanceof mongoose.Error.ValidationError){
+      err.status = 400;
+    }
+    return next(err);
   }
   return res.json(result);
 }
 
 const todoListController = {
-  getAll: (req, res) => {
+  getAll: (req, res, next) => {
     TodoItem.find({}, (err, todoItems) => {
-      return respond(err, todoItems, res);
+      return respond(err, todoItems, res, next);
     });
   },
-  create: (req, res) => {
+  create: (req, res, next) => {
     const newTodoItem = new TodoItem(req.body);
     newTodoItem.save((err, savedTodoItem) => {
-      return respond(err, savedTodoItem, res);
+      return respond(err, savedTodoItem, res, next);
     });
   },
-  get: (req, res) => {
+  get: (req, res, next) => {
     TodoItem.findById(req.params.id, (err, todoItem) => {
-      return respond(err, todoItem, res);
+      return respond(err, todoItem, res, next);
     });
   },
-  update: (req, res) => {
+  update: (req, res, next) => {
     TodoItem.findByIdAndUpdate(req.params.id, req.body, (err, todoItem) => {
-      return respond(err, todoItem, res);
+      return respond(err, todoItem, res, next);
     });
   },
-  delete: (req, res) => {
+  delete: (req, res, next) => {
     TodoItem.findByIdAndRemove(req.params.id, (err, todoItem) => {
-      return respond(err, todoItem, res);
+      return respond(err, todoItem, res, next);
     });
   }
 };

--- a/api/route/index.js
+++ b/api/route/index.js
@@ -8,7 +8,22 @@ module.exports = (app) => {
   app.route('/todoitems/:id').put(todoListController.update);
   app.route('/todoitems/:id').delete(todoListController.delete);
 
-  app.use((req, res) => {
-    res.status(404).json({url: req.originalUrl, error: 'not found'});
+  app.use((req, res, next) => {
+    next({status: 404, message: 'Invalid Path or Method'})
+  });
+
+  app.use(({status, message}, req, res, next) => {
+    const respStatus = status || 500;
+    const method = req.method.toUpperCase();
+    const url = req.originalUrl.toLowerCase();
+
+    let log = `****** ERROR ${respStatus} ******\n` ;
+    log += `On ${method} ${url}\n`;
+    log += message || '';
+    console.log(log);
+    res.status(respStatus).send({
+      error: message,
+      url, method,
+    });
   });
 };

--- a/index.js
+++ b/index.js
@@ -8,14 +8,20 @@ const app = express();
 const port = process.env.PORT || 3000;
 
 mongoose.Promise = global.Promise;
-mongoose.connect('mongodb://localhost/TodoListDB');
+
+mongoose.connect('mongodb://127.0.0.1:27017/TodoListDB', {
+    useNewUrlParser: true,
+    useUnifiedTopology: true,
+});
 
 app.use(bodyParser.urlencoded({extended: true}));
 app.use(bodyParser.json());
 
-routes(app);
-app.listen(port);
+(async () => {
+    await routes(app);
+    app.listen(port);
 
-console.log('Your first node api is running on port: ' + port);
+    console.log('Your first node api is running on port: ' + port);
+})();
 
 module.exports = app;


### PR DESCRIPTION
# Objectif

Implémenter un middleware Express de gestion d'erreur centralisé
- Faire remonter les erreurs dans une unique fonction afin d'en centraliser le traitement
- Unifier la réponse serveur en cas d'erreur

# Implémentation

## Express error handler
Implémenté dans `/api/routes/index.js` par le middleware ayant pour signature `({status, message}, req, res, next)`.

## Levée des erreurs dans le serveur
L'implémentation permet de lever un status de réponse adapté en ajoutant la propriété `status` à l'objet d'erreur, par exemple `err.status = 404`.
Par défaut, le statut sera `500` le cas échéant, essentiellement pour les erreurs non gérées.

Pour lever une erreur, il suffit d'envoyer notre erreur dans la fonction `next` du controlleur.
Exemple avec le controleur levant une 404 en cas de chemin ou méthode invalide.
````javascript
(req, res, next) => {
    next({status: 404, message: 'Invalid Path or Method'})
  }
````

## Réponse type en cas d'erreur
````json
{
error, // message d'erreur
url,
method
}
````

# Améliorations générales

## Modifications du TodoListController

- Modifications de la fonction `respond` pour utiliser le middleware de gestion d'erreur.
- Détection des erreurs de validation de champs par rapport au schéma avec levée d'un statut `400` tout en conservant le message de Mongoose. 

# Extension, alternatives...
## Messages centralisés et traduits
**pour une api publique**
Utiliser une collection de codes pour lever les erreurs, l'error handler récupèrerait le message dans la locale de la requête et l'ajouterait à la réponse serveur
## Classes d'erreur
Si l'on veut des erreurs plus détaillées et plus versatiles, on peut créer des classes internes d'erreur, ainsi dans les contrôleurs il suffirait d'appeler leur constructeur avec paramètres

````javascript
const customError = new QueryError([name, date]);
// customError.status: 400
// customError.message: "Invalid Field(s): 'name' should be 'X' / 'date' should be 'Y'"
next(new QueryError([name, date]))
````

