### PR TITLE
Unit Test for TodoList Controller Update function

### DIFF
--- a/api/controller/todoList.js
+++ b/api/controller/todoList.js
@@ -31,8 +31,10 @@ const todoListController = {
     });
   },
   update: (req, res, next) => {
-    TodoItem.findByIdAndUpdate(req.params.id, req.body, (err, todoItem) => {
-      return respond(err, todoItem, res, next);
+    TodoItem.findByIdAndUpdate(req.params.id, req.body,{
+      runValidators: true, returnDocument: 'after'},
+        (err, todoItem) => {
+        return respond(err, todoItem, res, next);
     });
   },
   delete: (req, res, next) => {

--- a/index.js
+++ b/index.js
@@ -9,18 +9,19 @@ const port = process.env.PORT || 3000;
 
 mongoose.Promise = global.Promise;
 
-mongoose.connect('mongodb://127.0.0.1:27017/TodoListDB', {
-    useNewUrlParser: true,
-    useUnifiedTopology: true,
-});
-
-app.use(bodyParser.urlencoded({extended: true}));
-app.use(bodyParser.json());
-
 (async () => {
+
+    await mongoose.connect('mongodb://127.0.0.1:27017/TodoListDB', {
+        useNewUrlParser: true,
+        useUnifiedTopology: true,
+        useFindAndModify: false,
+    });
+
+    app.use(bodyParser.urlencoded({extended: true}));
+    app.use(bodyParser.json());
+
     await routes(app);
     app.listen(port);
-
     console.log('Your first node api is running on port: ' + port);
 })();
 

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "My first NodeJs REST API to interact with a TodoList",
   "main": "index.js",
   "scripts": {
-    "test": "cross-env NODE_ENV=test mocha --recursive \"./test/**/*.js\"",
+    "test": "cross-env NODE_ENV=test mocha --recursive --exit \"./test/**/*.js\"",
     "start": "cross-env NODE_ENV=development node index.js"
   },
   "author": "",

--- a/package.json
+++ b/package.json
@@ -4,8 +4,8 @@
   "description": "My first NodeJs REST API to interact with a TodoList",
   "main": "index.js",
   "scripts": {
-    "test": " mocha --recursive \"./test/**/*.js\"",
-    "start": "node index.js"
+    "test": "cross-env NODE_ENV=test mocha --recursive \"./test/**/*.js\"",
+    "start": "cross-env NODE_ENV=development node index.js"
   },
   "author": "",
   "license": "MIT",
@@ -15,6 +15,7 @@
     "mongoose": "^5.7.8"
   },
   "devDependencies": {
+    "cross-env": "^7.0.3",
     "mocha": "^9.1.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "My first NodeJs REST API to interact with a TodoList",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1",
+    "test": " mocha --recursive \"./test/**/*.js\"",
     "start": "node index.js"
   },
   "author": "",
@@ -13,5 +13,8 @@
     "body-parser": "^1.17.1",
     "express": "^4.15.2",
     "mongoose": "^5.7.8"
+  },
+  "devDependencies": {
+    "mocha": "^9.1.3"
   }
 }

--- a/test/api/controller/toddoList.test.js
+++ b/test/api/controller/toddoList.test.js
@@ -21,7 +21,7 @@ const dummyResponse = {
     name: 'DummyResponse',
     content: null,
     callback: null,
-    json: (data) => dummyCallback.call(dummyResponse, data),
+    json: (data) => dummyCallback(data),
 };
 
 const dummyNext = {

--- a/test/api/controller/toddoList.test.js
+++ b/test/api/controller/toddoList.test.js
@@ -1,0 +1,110 @@
+'use strict';
+(async () => {
+    const app = await require('../../../index');
+})();
+
+const assert = require('assert');
+const mongoose = require('mongoose');
+
+const todoListController = require('../../../api/controller/todoList');
+const todoItem = require('../../../api/model/todoItem');
+
+const TodoItem = mongoose.model('TodoItem', todoItem);
+
+const dummyCallback = function(data){
+    console.log("Callback from", this.name);
+    this.content = data;
+    this.callback();
+}
+
+const dummyResponse = {
+    name: 'DummyResponse',
+    content: null,
+    callback: null,
+    json: (data) => dummyCallback.call(dummyResponse, data),
+};
+
+const dummyNext = {
+    name: 'DummyNext',
+    content: null,
+    callback: null,
+    next: (data) => dummyCallback.call(dummyNext, data),
+};
+
+const dummyRequest = ({name, status, id}) => {
+    return {
+        body: {name, status},
+        params: {id},
+    }
+};
+
+describe('TodoList Controller', function() {
+
+    describe('update', function () {
+        let dummyTodoItem = null;
+
+        before(async () => {
+            let newTodo = new TodoItem({
+                name: 'Test the TodoList Controller',
+            });
+            dummyTodoItem = await newTodo.save();
+            console.log(`Created dummy TodoItem`, dummyTodoItem);
+        });
+
+        after((done) => {
+            TodoItem.findByIdAndRemove(dummyTodoItem._id, (err, todoItem) => {
+                if(err) throw err;
+                console.log(`Dummy TodoItem deleted`, todoItem);
+                done();
+            });
+        });
+
+        beforeEach((done) => {
+            dummyResponse.content = null;
+            dummyResponse.callback = null;
+            dummyNext.content = null;
+            dummyNext.callback = null;
+            TodoItem.findById(dummyTodoItem._id,(err, todoItem) => {
+                if(err) throw err;
+                dummyTodoItem = todoItem;
+                done();
+            });
+        });
+
+        it('should update the fields of the todo item stored', (done)=> {
+            const modifiedTodoData =  {
+                name: "Make the test fail.",
+                status: 'done', id: dummyTodoItem._id,
+            };
+            dummyResponse.callback = () => {
+                assert.equal(modifiedTodoData.name, dummyResponse.content.name);
+                assert.equal(modifiedTodoData.status, dummyResponse.content.status);
+                assert.equal(modifiedTodoData.id.toString(), dummyResponse.content._id.toString());
+                done();
+            };
+
+            todoListController.update(
+                dummyRequest(modifiedTodoData),
+                dummyResponse, dummyNext.next
+            );
+        });
+
+        it('should set a 400 status if a ValidationError is raised', (done) => {
+            const wrongTodoItem = {
+                name: "Make the test fail.",
+                status: 'notAtAll', id: dummyTodoItem._id,
+            };
+
+            dummyNext.callback = () => {
+                assert.equal(400, dummyNext.content.status);
+                done();
+            }
+
+            todoListController.update(
+                dummyRequest(wrongTodoItem),
+                dummyResponse, dummyNext.next
+            );
+
+        });
+    });
+});


### PR DESCRIPTION
# Objectif
Créer des tests unitaires pour la function `update` du `todoList` controller.

## Cadre défini pour les tests unitaires
L'objectif a été de tester directement l'API publique du contrôleur. J'aurais pu considérer un test plus granulaire qui testerait également les fonctions privées du module (ici la fonction `respond`), ce qui impliquerait de devoir modifier les exports du module, donc les imports dans le code source, mais l'on transgresse les principes d'encapsulation, à moins de conditionner les exports des fonctions privées à un environnement de test.

# Implémentation

## Test Runner et Assertions
La suite de tests est lancée par `mocha`; la librairie d'assertion utilisée est `assert`, native à NodeJs.

## Mock-ups
Les fonctions de CRUD des modèles de Mongoose ne renvoient pas de promesse et utilisent des callbacks. Ce sont des fonctions impures qui rendent le test unitaire plus difficile.
Il aurait été possilbe de changer l'implémentation du contrôleur en mettant ses fonctions en asynchrone avec retour. J'ai choisi de conserver l'implémentation en cours puisqu'il reste possible de réaliser les tests ainsi.
J'ai créé des mock-ups d'objets de requête, réponse et de next qui sauvegardent les valeurs retournées après utilisation de la fonction du contrôleur et permettent d'éxécuter les assertions après son exécution de façon certaine, grâce à des callbacks.

# Améliorations générales
- utilisation de `cross-env` dans les scripts
- Ajout du code de connexion mongoose dans la fonction `async` de l'index  

# Extension, alternatives...
## Base de test
Le test utilise ici la même BDD en environnement de test et en production. Bien que le hook `after` de la suite de test supprime les données créées pour le test, il n'est pas judicieux d'utiliser la même base. Il faut envisager des jeux de variables d'environnement pour chacun afin que l'application utilise une base différente. Cela éviterait le duplicata sauvage du code de connexion dans le test de levée d'erreur (`todoList.test.js` l.125).
Il existe un module pour lancer une instance MongoDB en mémoire, ce qui permettrait de démarrer une suite de test directement avec l'application sur une BDD vierge, sans outil externe (mais installe le binaire de MongoDB, ce qui prend de la place).

## API end-to-end
En utilisant par exemple `chai` avec `chai-http`, on peut tester chacune des routes et vérifier l'intégration de notre contrôleur dans le serveur web, ainsi que la réponse de ce dernier.

## 'Fun' facts

### Await require
J'avais un doute sur une possible race condition sans await sur le require de l'application (je n'ai pas du importer de module avec du code async jusque là...). J'ai 'ralenti' le process de lancement de l'application avec un `await new Promise(resolve => setTimeout(resolve, 60000));` sans await, et **kaboom**, la suite de test se lance et donc sans application ni BDD, plante royalement! 

### Lancement le plus rapide
Lancer l'application au tout début de la page de test est l'éxécution la plus rapide.
Après les imports, avant la première suite de test ~+10ms.
Dans le hook `before` de la suite de test, ~+80ms.
Maintenant je sais!