### PR TITLE
Fix dummy Response CB

### DIFF
--- a/test/api/controller/toddoList.test.js
+++ b/test/api/controller/toddoList.test.js
@@ -21,7 +21,7 @@ const dummyResponse = {
     name: 'DummyResponse',
     content: null,
     callback: null,
-    json: (data) => dummyCallback.call(dummyResponse, data),
+    json: dummyCallback,
 };
 
 const dummyNext = {

--- a/test/api/controller/toddoList.test.js
+++ b/test/api/controller/toddoList.test.js
@@ -21,7 +21,7 @@ const dummyResponse = {
     name: 'DummyResponse',
     content: null,
     callback: null,
-    json: (data) => dummyCallback(data),
+    json: (data) => dummyCallback.call(dummyResponse, data),
 };
 
 const dummyNext = {


### PR DESCRIPTION
# Objectif
Une erreur s'est glissée dans le dernier commit de la branche `jo/unittest_update_todoitem` .
`dummyResponse.json` n'avait plus le contexte de l'objet, c'est réparé.
