### PR TITLE
Ajouter l'entité pour gérer les catégories de todo items

### DIFF
--- a/api/controller/categoryList.js
+++ b/api/controller/categoryList.js
@@ -1,0 +1,38 @@
+'use strict';
+const categorySchema = require('../model/category');
+const mongoose = require('mongoose');
+const CategoryModel = mongoose.model('CategoryModel', categorySchema);
+const { respond } = require('./helpers');
+
+const categoryController = {
+    getAll: (req, res, next) => {
+        CategoryModel.find({}, (err, categories) => {
+            return respond(err, categories, res, next);
+        });
+    },
+    create: (req, res, next) => {
+        const newCategoryItem = new CategoryModel(req.body);
+        newCategoryItem.save((err, savedCategoryItem) => {
+            return respond(err, savedCategoryItem, res, next);
+        });
+    },
+    get: (req, res, next) => {
+        CategoryModel.findById(req.params.id, (err, categoryItem) => {
+            return respond(err, categoryItem, res, next);
+        });
+    },
+    update: (req, res, next) => {
+        CategoryModel.findByIdAndUpdate(req.params.id, req.body,{
+                runValidators: true, returnDocument: 'after'},
+            (err, categoryItem) => {
+                return respond(err, categoryItem, res, next);
+            });
+    },
+    delete: (req, res, next) => {
+        CategoryModel.findByIdAndRemove(req.params.id, (err, categoryItem) => {
+            return respond(err, categoryItem, res, next);
+        });
+    }
+};
+
+module.exports = categoryController;

--- a/api/controller/helpers.js
+++ b/api/controller/helpers.js
@@ -1,0 +1,13 @@
+const mongoose = require("mongoose");
+
+function respond(err, result, res, next) {
+    if (err) {
+        if(err instanceof mongoose.Error.ValidationError){
+            err.status = 400;
+        }
+        return next(err);
+    }
+    return res.json(result);
+}
+
+module.exports = { respond };

--- a/api/controller/todoList.js
+++ b/api/controller/todoList.js
@@ -2,16 +2,7 @@
 const todoItem = require('../model/todoItem');
 const mongoose = require('mongoose');
 const TodoItem = mongoose.model('TodoItem', todoItem);
-
-function respond(err, result, res, next) {
-  if (err) {
-    if(err instanceof mongoose.Error.ValidationError){
-      err.status = 400;
-    }
-    return next(err);
-  }
-  return res.json(result);
-}
+const {respond} = require('./helpers');
 
 const todoListController = {
   getAll: (req, res, next) => {

--- a/api/model/category.js
+++ b/api/model/category.js
@@ -1,0 +1,9 @@
+'use strict';
+const mongoose = require('mongoose');
+const Schema = mongoose.Schema;
+
+const CategorySchema = new Schema({
+    name: {type: String, required: true, unique: true, lowercase: true},
+});
+
+module.exports = CategorySchema;

--- a/api/route/index.js
+++ b/api/route/index.js
@@ -1,5 +1,6 @@
 'use strict';
 const todoListController = require('../controller/todoList');
+const categoryController = require('../controller/categoryList');
 
 module.exports = (app) => {
   app.route('/todoitems').get(todoListController.getAll);
@@ -7,6 +8,12 @@ module.exports = (app) => {
   app.route('/todoitems/:id').get(todoListController.get);
   app.route('/todoitems/:id').put(todoListController.update);
   app.route('/todoitems/:id').delete(todoListController.delete);
+
+  app.route('/categories').get(categoryController.getAll);
+  app.route('/categories').post(categoryController.create);
+  app.route('/categories/:id').get(categoryController.get);
+  app.route('/categories/:id').put(categoryController.update);
+  app.route('/categories/:id').delete(categoryController.delete);
 
   app.use((req, res, next) => {
     next({status: 404, message: 'Invalid Path or Method'})


### PR DESCRIPTION
# Objectif
Implémenter un schéma et des routes pour gérer des catégories qui seront assignables aux item de la todo list.

# Implémentation
## Schéma
Champ `name` de type `String`, unique et requis.

## Contrôleur
Opérations CRUD et récupération de liste classiques (sur le modèle du contrôleur des todo).
J'avais pensé identifier les catégories plutôt avec l'attribut `name`, mais je me suis dit que pour récupérer une entité précise, la BDD est sûrement plus efficace avec un id. On pourra utiliser le `name` sur les routes des todoitems pour récupérer les todo d'une catégorie donnée en url params.

## Routes
Mêmes API REST que pour la gestion des todo, avec les 4 opérations CRUD + récupération de la liste des entités en BDD.

# Améliorations générales
## Controler Helpers
Ajout d'un fichier helpers dans le dossier des contrôleurs pour factoriser les fonctions support de ces derniers (ex `respond`).

# Extension, alternatives...
Rien de spécial pour le moment tant que l'entité n'est pas mise en relation avec les todo (prochaine PR)