### PR TITLE
Implementer les catégories aux todo

### DIFF
--- a/api/controller/categoryList.js
+++ b/api/controller/categoryList.js
@@ -1,7 +1,5 @@
 'use strict';
-const categorySchema = require('../model/category');
-const mongoose = require('mongoose');
-const CategoryModel = mongoose.model('CategoryModel', categorySchema);
+const CategoryModel = require('../model/category').model;
 const { respond } = require('./helpers');
 
 const categoryController = {

--- a/api/controller/categoryList.js
+++ b/api/controller/categoryList.js
@@ -1,5 +1,6 @@
 'use strict';
 const CategoryModel = require('../model/category').model;
+const TodoItemModel = require('../model/todoItem').model;
 const { respond } = require('./helpers');
 
 const categoryController = {
@@ -28,7 +29,10 @@ const categoryController = {
     },
     delete: (req, res, next) => {
         CategoryModel.findByIdAndRemove(req.params.id, (err, categoryItem) => {
-            return respond(err, categoryItem, res, next);
+            TodoItemModel.updateMany({categories: {$all: req.params.id}},
+                {$pull: {categories: req.params.id}}, (err) => {
+                    return respond(err, categoryItem, res, next);
+                });
         });
     }
 };

--- a/api/controller/helpers.js
+++ b/api/controller/helpers.js
@@ -10,4 +10,16 @@ function respond(err, result, res, next) {
     return res.json(result);
 }
 
-module.exports = { respond };
+function removeDuplicatesFromArray(arr){
+    const uniquesFound = new Map();
+    const uniquesArray = []
+    arr.forEach(ele => {
+        if(!uniquesFound.has(ele)) {
+            uniquesFound.set(ele, true);
+            uniquesArray.push(ele);
+        }
+    });
+    return uniquesArray;
+}
+
+module.exports = { respond, removeDuplicatesFromArray };

--- a/api/controller/todoList.js
+++ b/api/controller/todoList.js
@@ -1,7 +1,5 @@
 'use strict';
-const todoItem = require('../model/todoItem');
-const mongoose = require('mongoose');
-const TodoItem = mongoose.model('TodoItem', todoItem);
+const TodoItem = require('../model/todoItem').model;
 const {respond} = require('./helpers');
 
 const todoListController = {

--- a/api/controller/todoList.js
+++ b/api/controller/todoList.js
@@ -1,6 +1,6 @@
 'use strict';
 const TodoItem = require('../model/todoItem').model;
-const {respond} = require('./helpers');
+const {respond, removeDuplicatesFromArray } = require('./helpers');
 
 const todoListController = {
   getAll: (req, res, next) => {
@@ -9,6 +9,7 @@ const todoListController = {
     }).populate('categories');
   },
   create: (req, res, next) => {
+    req.body.categories = removeDuplicatesFromArray(req.body.categories);
     const newTodoItem = new TodoItem(req.body);
     newTodoItem.save((err, savedTodoItem) => {
       return respond(err, savedTodoItem, res, next);
@@ -20,6 +21,7 @@ const todoListController = {
     }).populate('categories');
   },
   update: (req, res, next) => {
+    req.body.categories = removeDuplicatesFromArray(req.body.categories);
     TodoItem.findByIdAndUpdate(req.params.id, req.body,{
       runValidators: true, returnDocument: 'after'},
         (err, todoItem) => {

--- a/api/controller/todoList.js
+++ b/api/controller/todoList.js
@@ -6,7 +6,7 @@ const todoListController = {
   getAll: (req, res, next) => {
     TodoItem.find({}, (err, todoItems) => {
       return respond(err, todoItems, res, next);
-    });
+    }).populate('categories');
   },
   create: (req, res, next) => {
     const newTodoItem = new TodoItem(req.body);
@@ -17,14 +17,14 @@ const todoListController = {
   get: (req, res, next) => {
     TodoItem.findById(req.params.id, (err, todoItem) => {
       return respond(err, todoItem, res, next);
-    });
+    }).populate('categories');
   },
   update: (req, res, next) => {
     TodoItem.findByIdAndUpdate(req.params.id, req.body,{
       runValidators: true, returnDocument: 'after'},
         (err, todoItem) => {
         return respond(err, todoItem, res, next);
-    });
+    }).populate('categories');
   },
   delete: (req, res, next) => {
     TodoItem.findByIdAndRemove(req.params.id, (err, todoItem) => {

--- a/api/model/category.js
+++ b/api/model/category.js
@@ -2,8 +2,14 @@
 const mongoose = require('mongoose');
 const Schema = mongoose.Schema;
 
-const CategorySchema = new Schema({
+const Category = {
+    name: 'Category',
+};
+
+Category.schema = new Schema({
     name: {type: String, required: true, unique: true, lowercase: true},
 });
 
-module.exports = CategorySchema;
+Category.model = mongoose.model(Category.name, Category.schema);
+
+module.exports = Category;

--- a/api/model/todoItem.js
+++ b/api/model/todoItem.js
@@ -20,6 +20,6 @@ TodoItem.schema = new Schema({
   {timestamps: true}
 );
 
-TodoItem.model = mongoose.model('TodoItemModel', TodoItem.schema);
+TodoItem.model = mongoose.model('TodoItem', TodoItem.schema);
 
 module.exports = TodoItem;

--- a/api/model/todoItem.js
+++ b/api/model/todoItem.js
@@ -1,12 +1,25 @@
 'use strict';
 const mongoose = require('mongoose');
 const Schema = mongoose.Schema;
+const CategoryName = require('./category').name;
 
-const TodoItemSchema = new Schema({
+const TodoItem = {
+    name: "TodoItem",
+}
+
+TodoItem.schema = new Schema({
     name: {type: String, required: true},
-    status: {type: String, enum: ['todo', 'inProgress', 'done'], default: 'todo', required: true}
+    status: {type: String, enum: ['todo', 'inProgress', 'done'], default: 'todo', required: true},
+    categories: [
+        {
+            type: Schema.Types.ObjectId,
+            ref: CategoryName,
+        },
+    ]
   },
   {timestamps: true}
 );
 
-module.exports = TodoItemSchema;
+TodoItem.model = mongoose.model('TodoItemModel', TodoItem.schema);
+
+module.exports = TodoItem;

--- a/test/api/controller/toddoList.test.js
+++ b/test/api/controller/toddoList.test.js
@@ -7,9 +7,7 @@ const assert = require('assert');
 const mongoose = require('mongoose');
 
 const todoListController = require('../../../api/controller/todoList');
-const todoItem = require('../../../api/model/todoItem');
-
-const TodoItem = mongoose.model('TodoItem', todoItem);
+const TodoItem = require('../../../api/model/todoItem').model;
 
 const dummyCallback = function(data){
     console.log("Callback from", this.name, 'executing...');


### PR DESCRIPTION
# Objectif

 Implementer les catégories aux todo.

# Implémentation

## Relation entre les entités
Many-to-Many (un todo peut avoir plusieurs catégories) => 0.N dans les deux sens, un todo peut ne pas avoir de catégorie.

### Réalisation avec Mongoose

Modification du schéma des todo avec le champs `categories`, array de références d'identifiants d'entités de catégories.
````javascript
TodoItem.schema = new Schema({
    name: {type: String, required: true},
    status: {type: String, enum: ['todo', 'inProgress', 'done'], default: 'todo', required: true},
    categories: [
        {
            type: Schema.Types.ObjectId,
            ref: CategoryName,
        },
    ]
  },
  {timestamps: true}
);
````

*Avantages*
- référence unique vers une catégorie, ce qui permet d'avoir le nom à jour de la catégorie, et par exemple faciliter les traductions

*Inconvénients*
- Devoir puller le nom pour chaque catégorie à chaque pull d'un todo, potentiellement plus de requêtes en interne.
- Edition peu facile des catégories des todo pour une API qui serait exposée publiquement, nécéssitant d'avoir pull les catégories auparavant pour les référencer.

Pas de référence dans le schéma des catégories vers les todo, cela fait peu de sens dans cette direction là. Pour récupérer les todo d'une catégorie, il suffit d'avoir une route du type `/todoitems/category/:category`, ou avec des query params `/todoitems?category=[dev, devops]` pour croiser plusieurs catégories.

### Questions
- Que faire quand une catégorie est supprimée en BDD? Je partirais sur retirer l'id de tous les todo qui l'ont. Quel est alors le mécanisme de cascade dans MongoDb?
**UPDATE**: Mongo ne réalise pas de cascade comme on pourrait le faire en SQL.  J'ai d'abord testé comment l'API réagissait à une catégorie supprimée en pullant un todo, dont je venais de supprimer l'une des catégories. La réponse n'affichait plus la catégorie en question. *Victoire*?! Hé bien **non**.  
En entrant dans la db via `mongosh` dans le container Docker, `use TodoLisDB` et `db.todoitems.find()`, j'ai affiché tous les todo, et l'on retrouve malgré tout toujours la référence à l'ObjectID de la catégorie supprimée dans les champ `categories` des toto qui l'avaient (mon intuition me disait bien que c'eut été trop facile).
Ainsi, j'ai modifié le contrôleur `delete` des catégories pour qu'il retrouve les todo ayant la catégorie supprimée et la retire de leurs données (vérifié dans le container).

## Validation du champ

Dans les contrôleurs des todo, il faut donc vérifier que chacune des catégories existe bien.

**UPDATE**: la validaton de l'existence d'un id se fait automatiquement; cependant l'unicité au sein de l'array n'est pas assurée si bien qu'*out of the box* une catégorie peut apparaître deux fois. 
La question se pose d'où veut-on appliquer cette *business rule*?
J'ai tenté avec des opérateurs de requête du style `$add_to_set: {categories: {$each: req.body.categories}` mais cela ne permet pas de remplacer l'array en BDD par celui envoyé, simplement d'ajouter les valeurs non présentes (ex: mon todo est en 'dev', mais je veux finalement juste lui mettre 'front', avec l'opérateur j'aurai au final les deux catégories).
Pour l'appliquer du côté de Mongo, il faudrait faire une aggrégation, et ne connaissant pas encore suffisamment le langage de requête, cela sort du contexte de l'exercice.
Ainsi, j'ai créé le helper:
````javascript
function removeDuplicatesFromArray(arr){
    const uniquesFound = new Map();
    const uniquesArray = []
    arr.forEach(ele => {
        if(!uniquesFound.has(ele)) {
            uniquesFound.set(ele, true);
            uniquesArray.push(ele);
        }
    });
    return uniquesArray;
}
````
Il est appliqué sur `req.body.categories` dans `create`  et `update` du contrôleur des todo. C'est donc du côté application que l'on force la business rule pour le moment. 

## Sortie d'API

Un todo retournée par l'API serait donc dans ce format:
````json
{
  name: "My todo to do",
  status: "todo",
  _id: "todoid1",
  categories: [
    {
      name: "Développement",
      _id: "catid1"
    },
    {
      name: "Architecture",
      _id: "catid2"
    },
  ]
}
````

# Améliorations générales

## Export des schémas et modèles
En voulant intégrer les catégories dans les todo item, je me rend compte que pour la référence, il fallait mieux avoir le nom du schéma à un seul endroit en dur dans le code. Auparavant, l'import des schéma dans les contrôleurs me chiffonnait également puisqu'on ne s'en servait pas à part pour implémenter une instance d'un modèle. J'ai donc choisir d'exporter depuis chaque fichier de modèle un objet selon l'interface:
````javascript
{
  name: "Entity",
  schema: EntitySchema // mongoose.Schema
  model: EntityModel // mongoose.Model
}
````
Ainsi on garde une référence unique depuis le fichier source pour chaque modèle. Et on simplifie les import dans les contrôleurs, qui n'ont même plus besoin de mongoose, ni d'instancier un modèle. 

## Controler DELETE Category - cascade sur les TodoItem
Le contrôleur `delete` pour les catégories supprime maintenant la référence à l'id de la catégorie supprimée de tout le catalogue des todo.
````javascript
    delete: (req, res, next) => {
        CategoryModel.findByIdAndRemove(req.params.id, (err, categoryItem) => {
            TodoItemModel.updateMany({categories: {$all: req.params.id}},
                {$pull: {categories: req.params.id}}, (err) => {
                    return respond(err, categoryItem, res, next);
                });
        });
    }
````
 
# Extension, alternatives...
## Optimiser les checks en BDD
Est-ce qu'il n'existerait pas un système de cache pour éviter de puller ou de check les catégories pour chaque requête sur chaque todo? A penser pour optimiser les traitements...