### PR TITLE
Route listant les todo pour une catégorie donnée

### DIFF
--- a/api/controller/categoryList.js
+++ b/api/controller/categoryList.js
@@ -1,35 +1,35 @@
 'use strict';
-const CategoryModel = require('../model/category').model;
-const TodoItemModel = require('../model/todoItem').model;
+const Category = require('../model/category').model;
+const TodoItem = require('../model/todoItem').model;
 const { respond } = require('./helpers');
 
 const categoryController = {
     getAll: (req, res, next) => {
-        CategoryModel.find({}, (err, categories) => {
+        Category.find({}, (err, categories) => {
             return respond(err, categories, res, next);
         });
     },
     create: (req, res, next) => {
-        const newCategoryItem = new CategoryModel(req.body);
+        const newCategoryItem = new Category(req.body);
         newCategoryItem.save((err, savedCategoryItem) => {
             return respond(err, savedCategoryItem, res, next);
         });
     },
     get: (req, res, next) => {
-        CategoryModel.findById(req.params.id, (err, categoryItem) => {
+        Category.findById(req.params.id, (err, categoryItem) => {
             return respond(err, categoryItem, res, next);
         });
     },
     update: (req, res, next) => {
-        CategoryModel.findByIdAndUpdate(req.params.id, req.body,{
+        Category.findByIdAndUpdate(req.params.id, req.body,{
                 runValidators: true, returnDocument: 'after'},
             (err, categoryItem) => {
                 return respond(err, categoryItem, res, next);
             });
     },
     delete: (req, res, next) => {
-        CategoryModel.findByIdAndRemove(req.params.id, (err, categoryItem) => {
-            TodoItemModel.updateMany({categories: {$all: req.params.id}},
+        Category.findByIdAndRemove(req.params.id, (err, categoryItem) => {
+            TodoItem.updateMany({categories: {$all: req.params.id}},
                 {$pull: {categories: req.params.id}}, (err) => {
                     return respond(err, categoryItem, res, next);
                 });

--- a/api/controller/todoList.js
+++ b/api/controller/todoList.js
@@ -3,8 +3,14 @@ const TodoItem = require('../model/todoItem').model;
 const {respond, removeDuplicatesFromArray } = require('./helpers');
 
 const todoListController = {
-  getAll: (req, res, next) => {
-    TodoItem.find({}, (err, todoItems) => {
+  getAll: async (req, res, next) => {
+    let filter = {};
+    if(req.params.categoryId){
+      filter = {
+        categories: req.params.categoryId
+      };
+    }
+    TodoItem.find(filter, (err, todoItems) => {
       return respond(err, todoItems, res, next);
     }).populate('categories');
   },

--- a/api/route/index.js
+++ b/api/route/index.js
@@ -9,6 +9,8 @@ module.exports = (app) => {
   app.route('/todoitems/:id').put(todoListController.update);
   app.route('/todoitems/:id').delete(todoListController.delete);
 
+  app.route('/todoitems/category/:categoryId').get(todoListController.getAll);
+
   app.route('/categories').get(categoryController.getAll);
   app.route('/categories').post(categoryController.create);
   app.route('/categories/:id').get(categoryController.get);


### PR DESCRIPTION
# Objectif

Retrouver les todo d'une catégorie donnée sur une route.

# Implémentation
## Route `/todoitems/category/:categoryId`
Utilise le contrôleur `getAll` qui est modifié pour ajuster le filtre de recherche en fonction de la présence du paramètre ou pas.
````javascript
  getAll: async (req, res, next) => {
    let filter = {};
    if(req.params.categoryId){
      filter = {
        categories: req.params.categoryId
      };
    }
    TodoItem.find(filter, (err, todoItems) => {
      return respond(err, todoItems, res, next);
    }).populate('categories');
  }
````

# Améliorations générales

# Extension, alternatives...

## Recherche des todo par nom de catégorie via query params
exemples: 
- `/todoitems?category=DevOps` 
- avec array   `/todoitems?category=[DevOps,Front-End]`
- avec des selecteurs plus complexes   `/todoitems?category[in]=[DevOps,Front-End]&category[notIn]=[Terraform]`

## Utiliser indifféremment nom et id
Dans les query params ou url params, en recherchant avec le model `Category.findOne({$or: [{name: "DevOps"}, {_id: "618d784aedb54956d1fe33d0"}]})`